### PR TITLE
Reposition customizer layout

### DIFF
--- a/assets/css/customizer.css
+++ b/assets/css/customizer.css
@@ -1,10 +1,12 @@
 .neon-wrap{background:#222;color:#fff;padding:20px;border-radius:8px;margin:16px 0}
 .neon-title{text-align:center;margin:0 0 10px}
+.neon-flex{display:flex;gap:20px;flex-wrap:wrap;align-items:flex-start}
 .preview{
   background:#333 center/cover no-repeat;
-  height:300px;display:flex;align-items:center;justify-content:center;border-radius:8px;margin-bottom:12px
+  height:300px;display:flex;align-items:center;justify-content:center;border-radius:8px;flex:1 1 50%;min-width:260px
 }
 .neon-text{font-size:50px;color:#fff;text-shadow:0 0 5px #f0f,0 0 10px #f0f,0 0 20px #f0f,0 0 40px #f0f;transition:all .2s ease}
+.controls{flex:1 1 40%;min-width:260px}
 .controls label{display:block;margin-top:10px;font-weight:600}
 .controls select,.controls input{padding:6px;margin-top:5px;width:100%;max-width:420px;background:#111;border:1px solid #444;color:#fff;border-radius:6px}
 .price{font-size:20px;margin-top:10px}

--- a/neon-sign-customizer-pro.php
+++ b/neon-sign-customizer-pro.php
@@ -23,7 +23,7 @@ class Neon_Sign_Customizer_PRO {
 
         // Front
         add_action('wp_enqueue_scripts', [$this,'assets']);
-        add_action('woocommerce_before_add_to_cart_button', [$this,'render'], 5);
+        add_action('wp', [$this,'setup_front']);
 
         // Cart / Order
         add_filter('woocommerce_add_cart_item_data', [$this,'cart_item_data'], 10, 3);
@@ -80,6 +80,16 @@ class Neon_Sign_Customizer_PRO {
         wp_enqueue_script('neon-pro', plugins_url('assets/js/customizer.js', __FILE__), ['jquery'], '1.2.0', true);
     }
 
+    function setup_front(){
+        if (!function_exists('is_product') || !is_product()) return;
+        global $post;
+        if(!$post) return;
+        if (get_post_meta($post->ID, self::META_ENABLED, true) !== 'yes') return;
+
+        remove_action('woocommerce_before_single_product_summary', 'woocommerce_show_product_images', 20);
+        add_action('woocommerce_before_single_product_summary', [$this,'render'], 20);
+    }
+
     function render(){
         global $product; if (!$product) return;
         if (get_post_meta($product->get_id(), self::META_ENABLED, true) !== 'yes') return;
@@ -94,11 +104,12 @@ class Neon_Sign_Customizer_PRO {
         <div id="neon-configurator" class="neon-wrap" data-base="<?php echo esc_attr($base); ?>" data-bg="<?php echo esc_attr($bg); ?>">
             <h2 class="neon-title"><?php esc_html_e('Create Your Neon Sign','neon'); ?></h2>
 
-            <div class="preview" <?php if($bg){ echo 'style="background-image:url('.esc_url($bg).')"'; } ?>>
-                <div id="previewText" class="neon-text">Let’s Create</div>
-            </div>
+            <div class="neon-flex">
+                <div class="preview" <?php if($bg){ echo 'style="background-image:url('.esc_url($bg).')"'; } ?>>
+                    <div id="previewText" class="neon-text">Let’s Create</div>
+                </div>
 
-            <div class="controls">
+                <div class="controls">
                 <label for="textInput"><?php esc_html_e('Write your text:','neon'); ?></label>
                 <input type="text" id="textInput" name="neon_text" value="Let’s Create" maxlength="<?php echo esc_attr($maxc); ?>" />
 
@@ -127,6 +138,7 @@ class Neon_Sign_Customizer_PRO {
 
                 <div class="price"><strong><?php esc_html_e('Price:','neon'); ?></strong> <span id="priceDisplay">$<?php echo esc_html(number_format((float)$base,2)); ?></span></div>
                 <input type="hidden" id="neon_estimated_price" name="neon_estimated_price" value="<?php echo esc_attr($base); ?>" />
+                </div>
             </div>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- move neon configurator before product summary and hide default gallery
- show preview and controls side by side with flexbox styling

## Testing
- `php -l neon-sign-customizer-pro.php`

------
https://chatgpt.com/codex/tasks/task_e_6895f1c00b8c8332878eec2e25f702f6