### PR TITLE
Remove dark wrapper background

### DIFF
--- a/assets/css/customizer.css
+++ b/assets/css/customizer.css
@@ -1,4 +1,4 @@
-.neon-wrap{background:#222;color:#fff;padding:20px;border-radius:8px;margin:16px 0}
+.neon-wrap{color:#111111;padding:20px;border-radius:8px;margin:16px 0}
 .neon-title{text-align:center;margin:0 0 10px}
 .neon-flex{display:flex;gap:20px;flex-wrap:wrap;align-items:flex-start}
 .preview{


### PR DESCRIPTION
## Summary
- remove #222 background on neon-wrap
- default neon-wrap text color to #111111

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l neon-sign-customizer-pro.php`


------
https://chatgpt.com/codex/tasks/task_e_6895f4cef7588332b78834e2ee459cf1