### PR TITLE
Refactor neon customizer layout and interactions

### DIFF
--- a/assets/css/customizer.css
+++ b/assets/css/customizer.css
@@ -1,12 +1,25 @@
-.neon-wrap{color:transparent;padding:20px;border-radius:8px;margin:16px 0}
-.neon-title{text-align:center;margin:0 0 10px}
-.neon-flex{display:flex;gap:20px;flex-wrap:wrap;align-items:flex-start}
-.preview{
-  background:#333 center/cover no-repeat;
-  height:600px;display:flex;align-items:center;justify-content:center;border-radius:8px;flex:1 1 50%;min-width:260px
-}
-.neon-text{font-size:50px;color:#111111;text-shadow:0 0 5px #f0f,0 0 10px #f0f,0 0 20px #f0f,0 0 40px #f0f;transition:all .2s ease}
-.controls{flex:1 1 40%;min-width:260px}
-.controls label{display:block;margin-top:10px;font-weight:600}
-.controls select,.controls input{padding:6px;margin-top:5px;width:100%;max-width:420px;background:#111;border:1px solid #444;color:#fff;border-radius:6px}
-.price{font-size:20px;margin-top:10px}
+/* Neon configurator styles */
+#neon-customizer.nf-wrap{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111;}
+.nf-grid{display:grid;grid-template-columns:56% 44%;gap:32px;align-items:start;}
+@media(max-width:899px){.nf-grid{grid-template-columns:1fr;gap:20px;}}
+.nf-mockup{background:#333 center/cover no-repeat;border-radius:8px;display:flex;align-items:center;justify-content:center;aspect-ratio:4/3;}
+#nf-preview.nf-neon{color:#fff;text-align:center;}
+.nf-panel{max-width:640px;}
+.nf-title{font-size:32px;font-weight:800;margin:0 0 8px;color:#111;}
+.nf-price{font-size:20px;font-weight:600;margin:0 0 16px;color:#111;}
+.nf-divider{height:1px;background:#F3F4F6;margin-bottom:16px;}
+.nf-field{margin-top:24px;}
+.nf-label{display:block;font-size:12px;font-weight:600;color:#6B7280;letter-spacing:.02em;margin-bottom:8px;text-transform:uppercase;}
+.nf-pills,.nf-fonts,.nf-colors{display:flex;flex-wrap:wrap;gap:8px;}
+.nf-chip{padding:8px 16px;border:1px solid #E5E7EB;border-radius:9999px;background:#fff;font-size:14px;color:#333;cursor:pointer;transition:box-shadow .15s,border-color .15s;}
+.nf-chip.is-active{border-color:#111;box-shadow:0 0 0 2px #0001;}
+.nf-chip:hover{box-shadow:0 1px 2px #0001;}
+.nf-color{width:32px;height:32px;border-radius:50%;border:1px solid #E5E7EB;background:var(--c);cursor:pointer;transition:box-shadow .15s,border-color .15s;}
+.nf-color.is-active{border-color:#111;box-shadow:0 0 0 2px var(--c);}
+.nf-color:hover{box-shadow:0 1px 2px #0001;}
+.nf-chip:focus-visible,.nf-color:focus-visible{outline:2px solid #111;outline-offset:2px;}
+#nf-text{width:100%;padding:8px;border:1px solid #E5E7EB;border-radius:8px;font-size:16px;color:#111;font-family:inherit;}
+.nf-help{display:flex;justify-content:space-between;font-size:12px;color:#6B7280;margin-top:8px;}
+#nf-count{font-weight:600;}
+.nf-warning{font-size:12px;color:#b45309;margin-top:4px;}
+@media(max-width:1199px){.nf-grid{grid-template-columns:60% 40%;}}

--- a/assets/js/customizer.js
+++ b/assets/js/customizer.js
@@ -1,32 +1,108 @@
 (function($){
-  function glow(c){ return `0 0 5px ${c},0 0 10px ${c},0 0 20px ${c},0 0 40px ${c}`; }
+  var $wrap = $('#neon-customizer');
+  if(!$wrap.length) return;
 
-  function update(){
-    var $w = $('#neon-configurator');
-    if(!$w.length) return;
-    var text = $('#textInput').val() || 'Your Text';
-    var inches = parseInt($('#sizeSelect').val() || 20, 10);
-    var font = $('#fontSelect').val() || "'Arial', sans-serif";
-    var color = $('#colorSelect').val() || '#ff00ff';
-    var base = parseFloat($w.data('base') || 112);
+  var base = parseFloat($wrap.data('base')) || 112;
+  var max = parseInt($wrap.data('max'),10) || 21;
 
-    $('#previewText').text(text).css({
-      fontFamily: font,
-      fontSize: (inches/3)+'px',
-      color: '#fff',
-      textShadow: glow(color)
-    });
+  var $textarea = $('#nf-text');
+  var $count = $('#nf-count');
+  var $price = $('#nf-price');
+  var $preview = $('#nf-preview');
+  var $warning = $('#nf-warning');
+  var $wHidden = $('#neon_width_in');
+  var $fHidden = $('#neon_font');
+  var $cHidden = $('#neon_color');
+  var $pHidden = $('#neon_estimated_price');
 
-    var price = base + (inches * 0.5) + (text.length * 2);
-    $('#priceDisplay').text('$' + price.toFixed(2));
-    $('#neon_estimated_price').val(price.toFixed(2));
+  function sanitize(str){
+    return str.replace(/[^\x20-\x7E\n]/g,'');
   }
 
-  $(document).on('input change', '#textInput,#sizeSelect,#fontSelect,#colorSelect', update);
-  $(document).ready(function(){
-    // Apply background if provided via data-bg attr
-    var bg = $('#neon-configurator').data('bg');
-    if(bg){ $('.preview').css('background-image','url('+bg+')'); }
+  function glow(c){
+    return '0 0 5px '+c+',0 0 10px '+c+',0 0 20px '+c+',0 0 30px '+c+',0 0 40px '+c;
+  }
+
+  var fontsLoaded = {};
+  function loadFont(font){
+    var fam = font.split(',')[0].replace(/["']/g,'').trim();
+    if(fontsLoaded[fam] || fam.toLowerCase()==='arial' || fam.toLowerCase()==='courier new') return;
+    fontsLoaded[fam]=true;
+    var link=document.createElement('link');
+    link.rel='stylesheet';
+    link.href='https://fonts.googleapis.com/css2?family='+encodeURIComponent(fam.replace(/ /g,'+'))+'&display=swap';
+    document.head.appendChild(link);
+  }
+
+  function update(){
+    var text = sanitize($textarea.val());
+    if($textarea.val()!==text) $textarea.val(text);
+    var len = text.length;
+    $count.text((max-len)+' characters left');
+    var longWord = text.split(/\s+/).some(function(w){return w.length>7;});
+    if(longWord){ $warning.text('Long word may exceed line limit'); } else { $warning.text(''); }
+    var inches = parseInt($wHidden.val(),10) || 0;
+    var font = $fHidden.val();
+    var color = $cHidden.val();
+    var display = text.trim()?text:'Let\u2019s Create';
+    loadFont(font);
+    $preview.text(display).css({
+      fontFamily: font,
+      fontSize: (inches/3)+'px',
+      color:'#fff',
+      textShadow: glow(color)
+    });
+    var price = base + (inches*0.5) + (len*2);
+    $price.text('$'+price.toFixed(2));
+    $pHidden.val(price.toFixed(2));
+  }
+
+  var debounceTimer;
+  function debouncedUpdate(){
+    clearTimeout(debounceTimer);
+    debounceTimer=setTimeout(update,80);
+  }
+
+  $('#nf-width').on('click','button',function(){
+    $('#nf-width button').removeClass('is-active').attr('aria-pressed','false');
+    $(this).addClass('is-active').attr('aria-pressed','true');
+    $wHidden.val($(this).data('in'));
     update();
   });
+
+  $('#nf-fonts').on('click','button',function(){
+    $('#nf-fonts button').removeClass('is-active').attr('aria-pressed','false');
+    $(this).addClass('is-active').attr('aria-pressed','true');
+    var font=$(this).data('font');
+    $fHidden.val(font);
+    update();
+  });
+
+  $('#nf-colors').on('click','button',function(){
+    $('#nf-colors button').removeClass('is-active').attr('aria-pressed','false');
+    $(this).addClass('is-active').attr('aria-pressed','true');
+    var color=$(this).data('color');
+    $cHidden.val(color);
+    update();
+  });
+
+  function navKeys(container, item){
+    $(container).on('keydown', item, function(e){
+      var $items=$(container).find(item);
+      var i=$items.index(this);
+      if(e.key==='ArrowRight'){ i=(i+1)%$items.length; $items.eq(i).focus(); e.preventDefault(); }
+      if(e.key==='ArrowLeft'){ i=(i-1+$items.length)%$items.length; $items.eq(i).focus(); e.preventDefault(); }
+      if(e.key==='Enter' || e.key===' '){ $(this).click(); e.preventDefault(); }
+    });
+  }
+  navKeys('#nf-width','button');
+  navKeys('#nf-fonts','button');
+  navKeys('#nf-colors','button');
+
+  $textarea.on('input', debouncedUpdate);
+
+  // preload first two fonts
+  loadFont($('#nf-fonts button').eq(0).data('font')||'');
+  loadFont($('#nf-fonts button').eq(1).data('font')||'');
+  update();
 })(jQuery);

--- a/neon-sign-customizer-pro.php
+++ b/neon-sign-customizer-pro.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Neon Sign Customizer PRO (WooCommerce)
  * Description: Exact neon customizer UI (preview + inches + price) embedded on product page, with dynamic cart price.
- * Version: 1.2.0
+ * Version: 1.3.0
  * Author: ChatGPT + Jose
  * Requires Plugins: woocommerce
  */
@@ -76,8 +76,8 @@ class Neon_Sign_Customizer_PRO {
 
     function assets(){
         if (!function_exists('is_product') || !is_product()) return;
-        wp_enqueue_style('neon-pro', plugins_url('assets/css/customizer.css', __FILE__), [], '1.2.0');
-        wp_enqueue_script('neon-pro', plugins_url('assets/js/customizer.js', __FILE__), ['jquery'], '1.2.0', true);
+        wp_enqueue_style('neon-pro', plugins_url('assets/css/customizer.css', __FILE__), [], '1.3.0');
+        wp_enqueue_script('neon-pro', plugins_url('assets/js/customizer.js', __FILE__), ['jquery'], '1.3.0', true);
     }
 
     function setup_front(){
@@ -87,7 +87,8 @@ class Neon_Sign_Customizer_PRO {
         if (get_post_meta($post->ID, self::META_ENABLED, true) !== 'yes') return;
 
         remove_action('woocommerce_before_single_product_summary', 'woocommerce_show_product_images', 20);
-        add_action('woocommerce_before_single_product_summary', [$this,'render'], 20);
+        remove_action('woocommerce_single_product_summary', 'woocommerce_template_single_price', 10);
+        add_action('woocommerce_before_add_to_cart_button', [$this,'render'], 5);
     }
 
     function render(){
@@ -99,45 +100,78 @@ class Neon_Sign_Customizer_PRO {
         $bg    = get_post_meta($product->get_id(), self::META_BG, true);
         $maxc  = get_post_meta($product->get_id(), self::META_MAX, true) ?: 21;
         $sizes_arr = array_filter(array_map('absint', explode(',', $sizes)));
+        if(empty($sizes_arr)) $sizes_arr=[20,29,40,60,79,99];
+        $sizes_attr = implode(',', $sizes_arr);
+        $fonts = [
+            "'Pacifico', cursive" => 'Pacifico',
+            "'Arial', sans-serif" => 'Arial',
+            "'Courier New', monospace" => 'Courier',
+            "'Lobster', cursive" => 'Lobster',
+        ];
+        $font_keys = array_keys($fonts);
+        $first_font = $font_keys[0];
+        $colors = [
+            '#ff00ff' => 'Pink',
+            '#00ffff' => 'Cyan',
+            '#ffff00' => 'Yellow',
+            '#ffffff' => 'White',
+        ];
+        $color_keys = array_keys($colors);
+        $first_color = $color_keys[0];
 
         ?>
-        <div id="neon-configurator" class="neon-wrap" data-base="<?php echo esc_attr($base); ?>" data-bg="<?php echo esc_attr($bg); ?>">
-            <h2 class="neon-title"><?php esc_html_e('Create Your Neon Sign','neon'); ?></h2>
-
-            <div class="neon-flex">
-                <div class="preview" <?php if($bg){ echo 'style="background-image:url('.esc_url($bg).')"'; } ?>>
-                    <div id="previewText" class="neon-text">Let’s Create</div>
+        <div id="neon-customizer" class="nf-wrap" data-base="<?php echo esc_attr($base); ?>" data-max="<?php echo esc_attr($maxc); ?>" data-bg="<?php echo esc_attr($bg); ?>" data-sizes="<?php echo esc_attr($sizes_attr); ?>">
+            <div class="nf-grid">
+                <div class="nf-mockup"<?php if($bg){ echo ' style="background-image:url('.esc_url($bg).')"'; } ?>>
+                    <div id="nf-preview" class="nf-neon">Let’s Create</div>
                 </div>
+                <div class="nf-panel">
+                    <h2 class="nf-title"><?php esc_html_e('Create your Neon Sign','neon'); ?></h2>
+                    <div id="nf-price" class="nf-price">$<?php echo esc_html(number_format((float)$base,2)); ?></div>
+                    <div class="nf-divider"></div>
 
-                <div class="controls">
-                <label for="textInput"><?php esc_html_e('Write your text:','neon'); ?></label>
-                <input type="text" id="textInput" name="neon_text" value="Let’s Create" maxlength="<?php echo esc_attr($maxc); ?>" />
+                    <div class="nf-field">
+                        <span class="nf-label"><?php esc_html_e('WIDTH','neon'); ?></span>
+                        <div id="nf-width" class="nf-pills">
+                            <?php foreach($sizes_arr as $i=>$in): $cm = round($in*2.5/5)*5; ?>
+                                <button type="button" role="button" aria-pressed="<?php echo $i===0?'true':'false'; ?>" class="nf-chip<?php echo $i===0?' is-active':''; ?>" data-in="<?php echo esc_attr($in); ?>"><?php echo esc_html($in.'" / '.$cm.' cm'); ?></button>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
 
-                <label for="sizeSelect"><?php esc_html_e('Select width (in):','neon'); ?></label>
-                <select id="sizeSelect" name="neon_size">
-                    <?php foreach($sizes_arr as $in): ?>
-                        <option value="<?php echo esc_attr($in); ?>"><?php echo esc_html($in.' in'); ?></option>
-                    <?php endforeach; ?>
-                </select>
+                    <div class="nf-help">
+                        <span><?php esc_html_e('MAX 7 LETTERS PER LINE','neon'); ?></span>
+                        <span id="nf-count" class="nf-count"><?php echo esc_html($maxc.' characters left'); ?></span>
+                    </div>
 
-                <label for="fontSelect"><?php esc_html_e('Select font:','neon'); ?></label>
-                <select id="fontSelect" name="neon_font">
-                    <option value="'Pacifico', cursive">Pacifico</option>
-                    <option value="'Arial', sans-serif">Arial</option>
-                    <option value="'Courier New', monospace">Courier</option>
-                    <option value="'Lobster', cursive">Lobster</option>
-                </select>
+                    <div class="nf-field">
+                        <span class="nf-label"><?php esc_html_e('WRITE YOUR TEXT','neon'); ?></span>
+                        <textarea id="nf-text" name="neon_text" maxlength="<?php echo esc_attr($maxc); ?>"></textarea>
+                        <div id="nf-warning" class="nf-warning" aria-live="polite"></div>
+                    </div>
 
-                <label for="colorSelect"><?php esc_html_e('Neon color:','neon'); ?></label>
-                <select id="colorSelect" name="neon_color">
-                    <option value="#ff00ff">Pink</option>
-                    <option value="#00ffff">Cyan</option>
-                    <option value="#ffff00">Yellow</option>
-                    <option value="#ffffff">White</option>
-                </select>
+                    <div class="nf-field">
+                        <span class="nf-label"><?php esc_html_e('CHOOSE YOUR FONT','neon'); ?></span>
+                        <div id="nf-fonts" class="nf-fonts">
+                            <?php $fi=0; foreach($fonts as $val=>$label): ?>
+                                <button type="button" role="button" aria-pressed="<?php echo $fi===0?'true':'false'; ?>" class="nf-chip<?php echo $fi===0?' is-active':''; ?>" data-font="<?php echo esc_attr($val); ?>" style="font-family:<?php echo esc_attr($val); ?>"><?php echo esc_html($label); ?></button>
+                            <?php $fi++; endforeach; ?>
+                        </div>
+                    </div>
 
-                <div class="price"><strong><?php esc_html_e('Price:','neon'); ?></strong> <span id="priceDisplay">$<?php echo esc_html(number_format((float)$base,2)); ?></span></div>
-                <input type="hidden" id="neon_estimated_price" name="neon_estimated_price" value="<?php echo esc_attr($base); ?>" />
+                    <div class="nf-field">
+                        <span class="nf-label"><?php esc_html_e('CHOOSE YOUR COLOR','neon'); ?></span>
+                        <div id="nf-colors" class="nf-colors">
+                            <?php $ci=0; foreach($colors as $val=>$name): ?>
+                                <button type="button" role="button" title="<?php echo esc_attr($name); ?>" aria-pressed="<?php echo $ci===0?'true':'false'; ?>" class="nf-color<?php echo $ci===0?' is-active':''; ?>" data-color="<?php echo esc_attr($val); ?>" style="--c:<?php echo esc_attr($val); ?>"></button>
+                            <?php $ci++; endforeach; ?>
+                        </div>
+                    </div>
+
+                    <input type="hidden" id="neon_width_in" name="neon_width_in" value="<?php echo esc_attr($sizes_arr[0]); ?>">
+                    <input type="hidden" id="neon_font" name="neon_font" value="<?php echo esc_attr($first_font); ?>">
+                    <input type="hidden" id="neon_color" name="neon_color" value="<?php echo esc_attr($first_color); ?>">
+                    <input type="hidden" id="neon_estimated_price" name="neon_estimated_price" value="<?php echo esc_attr(number_format((float)$base,2,'.','')); ?>">
                 </div>
             </div>
         </div>
@@ -145,13 +179,13 @@ class Neon_Sign_Customizer_PRO {
     }
 
     function cart_item_data($data, $product_id, $variation_id){
-        $fields = ['neon_text','neon_size','neon_font','neon_color','neon_estimated_price'];
+        $fields = ['neon_text','neon_width_in','neon_font','neon_color','neon_estimated_price'];
         $has = false; foreach($fields as $f){ if(isset($_POST[$f]) && $_POST[$f] !== ''){ $has=true; break; } }
         if(!$has) return $data;
 
         $data['neon'] = [
             'text'  => sanitize_text_field($_POST['neon_text'] ?? ''),
-            'size'  => absint($_POST['neon_size'] ?? 0),
+            'size'  => absint($_POST['neon_width_in'] ?? 0),
             'font'  => sanitize_text_field($_POST['neon_font'] ?? ''),
             'color' => sanitize_hex_color($_POST['neon_color'] ?? '#ff00ff'),
             'price' => (float) wc_format_decimal($_POST['neon_estimated_price'] ?? 0),


### PR DESCRIPTION
## Summary
- Redesign neon sign customizer to match two-column mockup layout with accessible controls
- Replace selects with width, font, and color chips tied to WooCommerce hidden fields
- Add live preview, character counter, and price calculation in JS

## Testing
- `php -l neon-sign-customizer-pro.php`
- `node --check assets/js/customizer.js`

------
https://chatgpt.com/codex/tasks/task_e_689a606277708332ac2bb846b8e82459