### PR TITLE
Fix customizer layout width

### DIFF
--- a/assets/css/customizer.css
+++ b/assets/css/customizer.css
@@ -1,5 +1,6 @@
 /* Neon configurator styles */
-#neon-customizer.nf-wrap{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111;}
+body.single-product div.product .summary{float:none;width:100%;}
+#neon-customizer.nf-wrap{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111;width:100%;max-width:1200px;margin:0 auto;}
 .nf-grid{display:grid;grid-template-columns:56% 44%;gap:32px;align-items:start;}
 @media(max-width:899px){.nf-grid{grid-template-columns:1fr;gap:20px;}}
 .nf-mockup{background:#333 center/cover no-repeat;border-radius:8px;display:flex;align-items:center;justify-content:center;aspect-ratio:4/3;}

--- a/neon-sign-customizer-pro.php
+++ b/neon-sign-customizer-pro.php
@@ -76,6 +76,9 @@ class Neon_Sign_Customizer_PRO {
 
     function assets(){
         if (!function_exists('is_product') || !is_product()) return;
+        global $post;
+        if(!$post) return;
+        if (get_post_meta($post->ID, self::META_ENABLED, true) !== 'yes') return;
         wp_enqueue_style('neon-pro', plugins_url('assets/css/customizer.css', __FILE__), [], '1.3.0');
         wp_enqueue_script('neon-pro', plugins_url('assets/js/customizer.js', __FILE__), ['jquery'], '1.3.0', true);
     }


### PR DESCRIPTION
## Summary
- Ensure product summary spans full width when neon customizer is active
- Center customizer container and limit max width
- Load customizer assets only when the feature is enabled

## Testing
- `php -l neon-sign-customizer-pro.php`


------
https://chatgpt.com/codex/tasks/task_e_689a637ec3e883329c421aebfa53d569