### PR TITLE
Fix mockup alignment by reusing WooCommerce image class

### DIFF
--- a/neon-sign-customizer-pro.php
+++ b/neon-sign-customizer-pro.php
@@ -104,7 +104,7 @@ class Neon_Sign_Customizer_PRO {
         if (get_post_meta($product->get_id(), self::META_ENABLED, true) !== 'yes') return;
 
         $bg = get_post_meta($product->get_id(), self::META_BG, true);
-        echo '<div class="nf-mockup"'.($bg ? ' style="background-image:url('.esc_url($bg).')"' : '').'>'; 
+        echo '<div class="woocommerce-product-gallery images nf-mockup"'.($bg ? ' style="background-image:url('.esc_url($bg).')"' : '').'>';
         echo '<div id="nf-preview" class="nf-neon">'.esc_html__("Let's Create",'neon').'</div>';
         echo '</div>';
     }


### PR DESCRIPTION
## Summary
- Ensure neon preview uses WooCommerce gallery image class so it floats left like default product images

## Testing
- `php -l neon-sign-customizer-pro.php`


------
https://chatgpt.com/codex/tasks/task_e_689aec8d2b2c83329f68e3c889b53f5a