### PR TITLE
Increase mockup preview size

### DIFF
--- a/assets/css/customizer.css
+++ b/assets/css/customizer.css
@@ -1,7 +1,7 @@
 /* Neon configurator styles */
 #neon-customizer.nf-wrap{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111;width:100%;max-width:1200px;margin:0 auto;}
-.woocommerce div.product .images{float:left;width:48%;margin-right:4%;}
-.woocommerce div.product .summary.entry-summary{float:left;width:48%;}
+.woocommerce div.product .images{float:left;width:60%;margin-right:4%;}
+.woocommerce div.product .summary.entry-summary{float:left;width:36%;}
 .nf-mockup{background:#333 center/cover no-repeat;border-radius:8px;display:flex;align-items:center;justify-content:center;aspect-ratio:4/3;}
 #nf-preview.nf-neon{color:#fff;text-align:center;}
 .nf-panel{max-width:640px;}

--- a/assets/js/customizer.js
+++ b/assets/js/customizer.js
@@ -48,7 +48,7 @@
     loadFont(font);
     $preview.text(display).css({
       fontFamily: font,
-      fontSize: (inches/3)+'px',
+      fontSize: (inches/2)+'px',
       color:'#fff',
       textShadow: glow(color)
     });


### PR DESCRIPTION
## Summary
- Widen mockup image column and shrink summary to highlight the preview
- Increase preview text scaling for a larger on-screen mockup

## Testing
- `npm test` (fails: Could not read package.json)
- `php -l neon-sign-customizer-pro.php`


------
https://chatgpt.com/codex/tasks/task_e_689aefb3a1888332addd808ddfe7c296