### PR TITLE
Increase preview text size

### DIFF
--- a/assets/js/customizer.js
+++ b/assets/js/customizer.js
@@ -48,7 +48,7 @@
     loadFont(font);
     $preview.text(display).css({
       fontFamily: font,
-      fontSize: (inches/2)+'px',
+      fontSize: (inches)+'px',
       color:'#fff',
       textShadow: glow(color)
     });


### PR DESCRIPTION
## Summary
- enlarge neon preview text size by using full width inches

## Testing
- `node --check assets/js/customizer.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689af1b9aeb08332bd70212abfe995e3