### PR TITLE
Fix product summary alignment

### DIFF
--- a/assets/css/customizer.css
+++ b/assets/css/customizer.css
@@ -1,7 +1,7 @@
 /* Neon configurator styles */
 #neon-customizer.nf-wrap{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111;width:100%;max-width:1200px;margin:0 auto;}
 .woocommerce div.product .images{float:left;width:70%;margin-right:4%;}
-.woocommerce div.product .summary.entry-summary{float:left;width:26%;}
+.woocommerce div.product .summary.entry-summary{float:left;width:26%;margin-top:0;clear:none;}
 .nf-mockup{background:#333 center/cover no-repeat;border-radius:8px;display:flex;align-items:center;justify-content:center;aspect-ratio:4/3;}
 #nf-preview.nf-neon{color:#fff;text-align:center;}
 .nf-panel{max-width:640px;}


### PR DESCRIPTION
## Summary
- ensure product summary starts at top next to canvas by removing unintended offset

## Testing
- `php -l neon-sign-customizer-pro.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5f917237c8332afe710c60bab8a9e