### PR TITLE
Align preview canvas with product summary

### DIFF
--- a/assets/css/customizer.css
+++ b/assets/css/customizer.css
@@ -1,7 +1,14 @@
 /* Neon configurator styles */
 #neon-customizer.nf-wrap{font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#111;width:100%;max-width:1200px;margin:0 auto;}
-.woocommerce div.product .images{float:left;width:48%;margin-right:4%;}
-.woocommerce div.product .summary.entry-summary{float:left;width:48%;}
+
+.nf-product-layout{display:flex;flex-wrap:wrap;align-items:flex-start;}
+.nf-product-layout .nf-mockup{flex:1 1 48%;margin-right:4%;}
+.nf-product-layout .summary.entry-summary{flex:1 1 48%;}
+@media(max-width:768px){
+  .nf-product-layout{flex-direction:column;}
+  .nf-product-layout .nf-mockup,
+  .nf-product-layout .summary.entry-summary{flex:1 1 100%;margin-right:0;}
+}
 .nf-mockup{background:#333 center/cover no-repeat;border-radius:8px;display:flex;align-items:center;justify-content:center;aspect-ratio:4/3;}
 #nf-preview.nf-neon{color:#fff;text-align:center;}
 .nf-panel{max-width:640px;}

--- a/assets/js/customizer.js
+++ b/assets/js/customizer.js
@@ -2,6 +2,15 @@
   var $wrap = $('#neon-customizer');
   if(!$wrap.length) return;
 
+  // Arrange preview canvas and product summary side by side
+  var $product = $wrap.closest('.product');
+  var $mockup = $product.find('.nf-mockup');
+  var $summary = $product.find('.summary.entry-summary');
+  if($mockup.length && $summary.length){
+    $mockup.insertBefore($summary);
+    $mockup.add($summary).wrapAll('<div class="nf-product-layout"></div>');
+  }
+
   var base = parseFloat($wrap.data('base')) || 112;
   var max = parseInt($wrap.data('max'),10) || 21;
 


### PR DESCRIPTION
## Summary
- Arrange preview canvas and product summary within a flex container so details sit beside the canvas
- Add responsive CSS to keep layout side‑by‑side on desktop and stacked on mobile

## Testing
- `node --check assets/js/customizer.js`
- `php -l neon-sign-customizer-pro.php`


------
https://chatgpt.com/codex/tasks/task_e_68a613a134f883329ef8401f7cafab26