### PR TITLE
Fix customizer fields not captured in cart

### DIFF
--- a/neon-sign-customizer-pro.php
+++ b/neon-sign-customizer-pro.php
@@ -97,8 +97,8 @@ class Neon_Sign_Customizer_PRO {
         // Render preview where the product images usually appear
         add_action('woocommerce_before_single_product_summary', [$this,'render_mockup'], 20);
 
-        // Render the configurator panel inside the product summary
-        add_action('woocommerce_single_product_summary', [$this,'render_panel'], 5);
+        // Render the configurator panel inside the add to cart form
+        add_action('woocommerce_before_add_to_cart_button', [$this,'render_panel'], 5);
     }
 
     function render_mockup(){


### PR DESCRIPTION
## Summary
- Render neon customizer panel inside WooCommerce add-to-cart form so custom text, size, font, color and preview image are submitted.

## Testing
- `php -l neon-sign-customizer-pro.php`
- `node --check assets/js/customizer.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6443c903c833289eb6b43b71c4b61